### PR TITLE
Update branch names from master to main

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,10 +1,10 @@
 name: workflow.yml
 on:
   push:
-    branches: [ "master", "dev-master" ]
+    branches: [ "main", "dev-main" ]
 
   pull_request:
-    branches: [ "master", "dev-master" ]
+    branches: [ "main", "dev-main" ]
 
 jobs:
   build-and-test:


### PR DESCRIPTION
This pull request updates the branch names in the GitHub Actions workflow configuration to align with the current branch naming conventions.

Workflow configuration update:

* [`.github/workflows/workflow.yml`](diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1L4-R7): Changed the workflow triggers from `master` and `dev-master` branches to `main` and `dev-main` branches for both `push` and `pull_request` events.